### PR TITLE
Sign and verifying messages

### DIFF
--- a/core/account.js
+++ b/core/account.js
@@ -16,7 +16,7 @@ const blockchain = require('core/blockchain');
 /**
  * SECP256K1 prefix.
  *
- * @see {@link https://bitcoin.stackexchange.com/questions/57855/c-secp256k1-what-do-prefixes-0x06-and-0x07-in-an-uncompressed-public-key-signif}
+ * @see  {@link https://bitcoin.stackexchange.com/questions/57855/c-secp256k1-what-do-prefixes-0x06-and-0x07-in-an-uncompressed-public-key-signif}
  * @type {Buffer}
  */
 const SECP256K1_PREFIX = Buffer.from('04', 'hex');

--- a/core/account.js
+++ b/core/account.js
@@ -14,12 +14,9 @@ const constants     = require('lib/constants');
 const blockchain    = require('core/blockchain');
 
 /**
+ * SECP256K1 prefix.
  *
- * SECP256K1 prefix
- *
- * More details could be found
- * https://bitcoin.stackexchange.com/questions/57855/c-secp256k1-what-do-prefixes-0x06-and-0x07-in-an-uncompressed-public-key-signif
- *
+ * @see {@link https://bitcoin.stackexchange.com/questions/57855/c-secp256k1-what-do-prefixes-0x06-and-0x07-in-an-uncompressed-public-key-signif}
  * @type {Buffer}
  */
 const SECP256K1_PREFIX = Buffer.from('04', 'hex');
@@ -83,44 +80,29 @@ Account.prototype.tx = function tx(to, value, data='0x00') {
 };
 
 /**
+ * Signing message by account private key.
  *
- * Signing message by account
- *
- * @param {String} message Text message to sign
- * @return {Object} Message
+ * @param {String} message Text message to sign.
+ * @return {Buffer} Signature of message.
  */
 Account.prototype.signMessage = function signMessage(message) {
-    let signedMessage = {};
+    const hash = keccak256(Buffer.from(message));
 
-    signedMessage.publicKey = this.publicKey;
-    signedMessage.message = message;
-
-    let hash = keccak256(Buffer.from(message));
-    signedMessage.signature = secp256k1.sign(hash, this.secretKey).signature;
-
-    return signedMessage;
+    return secp256k1.sign(hash, this.secretKey).signature;
 }
 
 /**
+ * Verifying message signed by account.
  *
- * Verifying message signed by account
- *
- * @param {Object} Message object signed by signMessage function
- * @param {Buffer} Public key if signed message doesn't contain public key or need another public key
- *
- * @return {Boolean} Result of signature verification
+ * @param {String} message Message to verify.
+ * @param {Buffer} publicKey Public key of account that signed message.
+ * @param {Buffer} signature Signature of message.
+ * @return {Boolean} Result of signature verification.
  */
-Account.verifyMessage = function verifyMessage(signedMessage, publicKey) {
-    let pbK = publicKey || signedMessage.publicKey;
+Account.verifyMessage = function verifyMessage(message, publicKey, signature) {
+    const hash = keccak256(Buffer.from(message));
 
-    if (!pbK) {
-        throw 'You use provide public key as function parameter or as part of signed message';
-    }
-
-    let hash = keccak256(Buffer.from(signedMessage.message));
-
-
-    return secp256k1.verify(hash, signedMessage.signature, Buffer.concat([SECP256K1_PREFIX, pbK]));
+    return secp256k1.verify(hash, signature, Buffer.concat([SECP256K1_PREFIX, publicKey]));
 }
 
 /**

--- a/core/account.js
+++ b/core/account.js
@@ -15,7 +15,7 @@ const blockchain    = require('core/blockchain');
 
 /**
  *
- * Our SECP256K1 prefix
+ * SECP256K1 prefix
  *
  * More details could be found
  * https://bitcoin.stackexchange.com/questions/57855/c-secp256k1-what-do-prefixes-0x06-and-0x07-in-an-uncompressed-public-key-signif

--- a/core/account.js
+++ b/core/account.js
@@ -6,12 +6,12 @@
 
 'use strict';
 
-const secp256k1     = require('secp256k1');
-const keccak256     = require('keccak256');
-const ethereumTx    = require('ethereumjs-tx');
-const helpers       = require('lib/helpers');
-const constants     = require('lib/constants');
-const blockchain    = require('core/blockchain');
+const secp256k1  = require('secp256k1');
+const keccak256  = require('keccak256');
+const ethereumTx = require('ethereumjs-tx');
+const helpers    = require('lib/helpers');
+const constants  = require('lib/constants');
+const blockchain = require('core/blockchain');
 
 /**
  * SECP256K1 prefix.
@@ -82,8 +82,8 @@ Account.prototype.tx = function tx(to, value, data='0x00') {
 /**
  * Signing message by account private key.
  *
- * @param {String} message Text message to sign.
- * @return {Buffer} Signature of message.
+ * @param  {String} message Text message to sign.
+ * @return {Buffer}         Signature of message.
  */
 Account.prototype.signMessage = function signMessage(message) {
     const hash = keccak256(Buffer.from(message));
@@ -94,10 +94,10 @@ Account.prototype.signMessage = function signMessage(message) {
 /**
  * Verifying message signed by account.
  *
- * @param {String} message Message to verify.
- * @param {Buffer} publicKey Public key of account that signed message.
- * @param {Buffer} signature Signature of message.
- * @return {Boolean} Result of signature verification.
+ * @param  {String}  message   Message to verify.
+ * @param  {Buffer}  publicKey Public key of account that signed message.
+ * @param  {Buffer}  signature Signature of message.
+ * @return {Boolean}           Result of signature verification.
  */
 Account.verifyMessage = function verifyMessage(message, publicKey, signature) {
     const hash = keccak256(Buffer.from(message));

--- a/test/unit/account.js
+++ b/test/unit/account.js
@@ -22,9 +22,11 @@ describe('Accounts', () => {
     let account = {};
     let target  = {};
     let block   = {};
+    let signedMessage = {};
 
     const AMOUNT_TO_STAKE = 200;
     const AMOUNT_TO_VOTE  = 100;
+    const MESSAGE = 'hello, this is some message';
 
     let transactions = [];
 
@@ -89,6 +91,37 @@ describe('Accounts', () => {
 
         console.log('Delegates:', normalizedState.delegates);
         console.log('Amount of certificates:', normalizedState.totalCertificates);
+    });
+
+    it('sign message with account secret key', () => {
+        signedMessage = account.signMessage(MESSAGE);
+
+        signedMessage.message.should.be.string;
+        signedMessage.signature.length.should.be.equal(64);
+        signedMessage.publicKey.length.should.be.equal(64);
+        console.log('Signed message: ', signedMessage);
+    });
+
+    it('verify signed message', () => {
+        const verified = Account.verifyMessage(signedMessage);
+        verified.should.be.true;
+    });
+
+    it('verify signed message by public key', () => {
+        const verified = Account.verifyMessage(signedMessage, account.publicKey);
+        verified.should.be.true;
+    });
+
+    it('verify signed message with wrong message', () => {
+        signedMessage.message = 'not that message';
+        const verified = Account.verifyMessage(signedMessage);
+        signedMessage.message = MESSAGE;
+        verified.should.be.false;
+    });
+
+    it('verify signed message with wrong public key', () => {
+        const verified = Account.verifyMessage(signedMessage, target.publicKey);
+        verified.should.be.false;
     });
 
     xit('produce second block', () => {

--- a/test/unit/account.js
+++ b/test/unit/account.js
@@ -22,7 +22,7 @@ describe('Accounts', () => {
     let account = {};
     let target  = {};
     let block   = {};
-    let signedMessage = {};
+    let signature = null;
 
     const AMOUNT_TO_STAKE = 200;
     const AMOUNT_TO_VOTE  = 100;
@@ -94,33 +94,24 @@ describe('Accounts', () => {
     });
 
     it('sign message with account secret key', () => {
-        signedMessage = account.signMessage(MESSAGE);
+        signature = account.signMessage(MESSAGE);
 
-        signedMessage.message.should.be.string;
-        signedMessage.signature.length.should.be.equal(64);
-        signedMessage.publicKey.length.should.be.equal(64);
-        console.log('Signed message: ', signedMessage);
+        signature.length.should.be.equal(64);
+        console.log('Signature: ', signature);
     });
 
     it('verify signed message', () => {
-        const verified = Account.verifyMessage(signedMessage);
-        verified.should.be.true;
-    });
-
-    it('verify signed message by public key', () => {
-        const verified = Account.verifyMessage(signedMessage, account.publicKey);
+        const verified = Account.verifyMessage(MESSAGE, account.publicKey, signature);
         verified.should.be.true;
     });
 
     it('verify signed message with wrong message', () => {
-        signedMessage.message = 'not that message';
-        const verified = Account.verifyMessage(signedMessage);
-        signedMessage.message = MESSAGE;
+        const verified = Account.verifyMessage('not that message', account.publicKey, signature);
         verified.should.be.false;
     });
 
     it('verify signed message with wrong public key', () => {
-        const verified = Account.verifyMessage(signedMessage, target.publicKey);
+        const verified = Account.verifyMessage(MESSAGE, target.publicKey, signature);
         verified.should.be.false;
     });
 


### PR DESCRIPTION
Adds sign/verify methods to core/account

- to sign a message you now can do account.signMessage(msg)
- to verify you use: Account.verifyMessage(msg, pk) 